### PR TITLE
feat: implement Catppuccin Mocha theme for macOS and iOS

### DIFF
--- a/apple/InlineIOS/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apple/InlineIOS/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.980",
+          "green" : "0.706",
+          "red" : "0.537"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/apple/InlineIOS/UI/Themes.swift
+++ b/apple/InlineIOS/UI/Themes.swift
@@ -1,38 +1,26 @@
 import SwiftUI
 
 struct Default: ThemeConfig {
-  var primaryTextColor: UIColor?
+  var primaryTextColor: UIColor? = .init(hex: "#cdd6f4")!
 
-  var secondaryTextColor: UIColor?
+  var secondaryTextColor: UIColor? = .init(hex: "#a6adc8")!
 
   var id: String = "Default"
 
   var name: String = "Default"
 
-  var backgroundColor: UIColor = .systemBackground
+  var backgroundColor: UIColor = .init(hex: "#1e1e2e")!
 
-  var bubbleBackground: UIColor = .init(hex: "#52A5FF")!
-  var incomingBubbleBackground: UIColor = .init(dynamicProvider: { trait in
-    if trait.userInterfaceStyle == .dark {
-      UIColor(hex: "#27262B")!
-    } else {
-      UIColor(hex: "#F2F2F2")!
-    }
-  })
+  var bubbleBackground: UIColor = .init(hex: "#89b4fa")!
+  var incomingBubbleBackground: UIColor = .init(hex: "#45475a")!
 
-  var accent: UIColor = .init(hex: "#52A5FF")!
+  var accent: UIColor = .init(hex: "#89b4fa")!
 
   var reactionOutgoingPrimary: UIColor? = .white
   var reactionOutgoingSecoundry: UIColor? = .white.withAlphaComponent(0.08)
 
   var reactionIncomingPrimary: UIColor? { accent }
-  var reactionIncomingSecoundry: UIColor? = .init(dynamicProvider: { trait in
-    if trait.userInterfaceStyle == .dark {
-      UIColor(hex: "#3c3b43")!
-    } else {
-      UIColor(hex: "#e2e5e5")!
-    }
-  })
+  var reactionIncomingSecoundry: UIColor? = .init(hex: "#585b70")!
 }
 
 struct Lavender: ThemeConfig {

--- a/apple/InlineMac/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apple/InlineMac/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.976",
-          "green" : "0.510",
-          "red" : "0.600"
+          "blue" : "0.980",
+          "green" : "0.706",
+          "red" : "0.537"
         }
       },
       "idiom" : "universal"

--- a/apple/InlineMac/Utils/Theme.swift
+++ b/apple/InlineMac/Utils/Theme.swift
@@ -15,16 +15,12 @@ enum Theme {
 
   // MARK: - Colors
 
-  static let colorIconGray: NSColor = .init(name: "colorIconGray") { appearance in
-    appearance.name == .darkAqua ?
-      NSColor(red: 146 / 255, green: 146 / 255, blue: 146 / 255, alpha: 1) :
-      NSColor(red: 188 / 255, green: 188 / 255, blue: 188 / 255, alpha: 1)
+  static let colorIconGray: NSColor = .init(name: "colorIconGray") { _ in
+    NSColor(red: 166 / 255, green: 173 / 255, blue: 200 / 255, alpha: 1)
   }
 
-  static let colorTitleTextGray: NSColor = .init(name: "colorTitleTextGray") { appearance in
-    appearance.name == .darkAqua ?
-      NSColor(red: 160 / 255, green: 160 / 255, blue: 160 / 255, alpha: 1) :
-      NSColor(red: 158 / 255, green: 158 / 255, blue: 158 / 255, alpha: 1)
+  static let colorTitleTextGray: NSColor = .init(name: "colorTitleTextGray") { _ in
+    NSColor(red: 186 / 255, green: 194 / 255, blue: 222 / 255, alpha: 1)
   }
 
   // MARK: - Window
@@ -79,28 +75,22 @@ enum Theme {
   }
 
   // - after bubble -
-  static let messageBubblePrimaryBgColor: NSColor = .init(name: "messageBubblePrimaryBgColor") { appearance in
-    appearance.name == .darkAqua ? NSColor(
-      calibratedRed: 120 / 255,
-      green: 94 / 255,
-      blue: 212 / 255,
-      alpha: 1.0
-    ) : NSColor(
-      calibratedRed: 143 / 255,
-      green: 116 / 255,
-      blue: 238 / 255,
+  static let messageBubblePrimaryBgColor: NSColor = .init(name: "messageBubblePrimaryBgColor") { _ in
+    NSColor(
+      calibratedRed: 137 / 255,
+      green: 180 / 255,
+      blue: 250 / 255,
       alpha: 1.0
     )
   }
 
-  static let messageBubbleSecondaryBgColor: NSColor = .init(name: "messageBubbleSecondaryBgColor") { appearance in
-    appearance.name == .darkAqua ? NSColor.white
-      .withAlphaComponent(0.1) : .init(
-        calibratedRed: 236 / 255,
-        green: 236 / 255,
-        blue: 236 / 255,
-        alpha: 1.0
-      )
+  static let messageBubbleSecondaryBgColor: NSColor = .init(name: "messageBubbleSecondaryBgColor") { _ in
+    NSColor(
+      calibratedRed: 69 / 255,
+      green: 71 / 255,
+      blue: 90 / 255,
+      alpha: 1.0
+    )
   }
 
   /// used for bubbles diff to edge
@@ -132,10 +122,13 @@ enum Theme {
   static let composeTextViewHorizontalPadding: CGFloat = 10.0
   static let composeVerticalPadding: CGFloat = 2.0 // inner, higher makes 2 line compose increase height
   static let composeOuterSpacing: CGFloat = 18 // horizontal
-  static let composeOutlineColor: NSColor = .init(name: "composeOutlineColor") { appearance in
-    appearance.name == .darkAqua ? NSColor.white
-      .withAlphaComponent(0.1) : NSColor.black
-      .withAlphaComponent(0.09)
+  static let composeOutlineColor: NSColor = .init(name: "composeOutlineColor") { _ in
+    NSColor(
+      calibratedRed: 88 / 255,
+      green: 91 / 255,
+      blue: 112 / 255,
+      alpha: 1.0
+    )
   }
 
   // MARK: - Devtools


### PR DESCRIPTION
## Summary
- update macOS theme colors to Catppuccin Mocha palette
- update iOS default theme with Catppuccin Mocha colors
- set accent color assets to Catppuccin Blue

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68593efc19d883279eb5319830241702